### PR TITLE
Alternative linear layer implementation

### DIFF
--- a/gatr/layers/linear.py
+++ b/gatr/layers/linear.py
@@ -7,13 +7,13 @@ import torch
 from torch import nn
 
 from gatr.interface import embed_scalar
-from gatr.primitives.linear import equi_linear
+from gatr.primitives.linear import equi_linear, USE_FULLY_CONNECTED_SUBGROUP
 
 # switch to mix pseudoscalar multivector components directly into scalar components
 # this only makes sense when working with the special orthochronous Lorentz group,
 # Note: This is an efficiency boost, the same action can be achieved with an extra linear layer
 MIX_MVPSEUDOSCALAR_INTO_SCALAR = True
-NUM_PIN_LINEAR_BASIS_ELEMENTS = 10
+NUM_PIN_LINEAR_BASIS_ELEMENTS = 10 if USE_FULLY_CONNECTED_SUBGROUP else 5
 
 
 class EquiLinear(nn.Module):

--- a/gatr/primitives/linear.py
+++ b/gatr/primitives/linear.py
@@ -11,7 +11,7 @@ from gatr.utils.einsum import cached_einsum, custom_einsum
 # They only differ in the construction of linear maps in _compute_pin_equi_linear_basis
 USE_FULLY_CONNECTED_SUBGROUP = True
 
-LINEAR_V2 = True
+LINEAR_V2 = False
 
 
 @lru_cache()
@@ -127,9 +127,9 @@ def linear_v2(x, coeffs):
     return out
 
 
-@torch.compile()
+@torch.compile(dynamic=True)
 def linear_v2_compiled(*args):
-    linear_v2(*args)
+    return linear_v2(*args)
 
 
 def equi_linear(

--- a/tests/benchmarks/benchmark_linear.py
+++ b/tests/benchmarks/benchmark_linear.py
@@ -102,7 +102,8 @@ if __name__ == "__main__":
     axs[1].plot(n_particles, v3_mean / v1_mean, color="b")
     axs[1].set_ylabel(r"$t_{v2}/t_{v1}$")
 
-    fig.suptitle(f"Time benchmarking for linear layer on {DEVICE}")
+    full_str1 = r"$SO^+(1,3)$" if USE_FULLY_CONNECTED_SUBGROUP else r"$O(1,3)$"
+    fig.suptitle(f"Time benchmark linear layer on {DEVICE} for {full_str1}")
     full_str = "SO+13" if USE_FULLY_CONNECTED_SUBGROUP else "O13"
     fig.savefig(f"benchmark_{DEVICE}_{full_str}.pdf", bbox_inches="tight")
     plt.close()

--- a/tests/benchmarks/benchmark_linear.py
+++ b/tests/benchmarks/benchmark_linear.py
@@ -1,0 +1,108 @@
+import torch, time
+import numpy as np
+import matplotlib.pyplot as plt
+
+from gatr.primitives.linear import (
+    equi_linear,
+    linear_v2,
+    linear_v2_compiled,
+    USE_FULLY_CONNECTED_SUBGROUP,
+)
+from gatr.layers.linear import NUM_PIN_LINEAR_BASIS_ELEMENTS
+
+DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+DTYPE = torch.float32
+
+
+def benchmark(n_particles):
+    # create data
+    batchsize, channels = n_particles, 32
+    x = torch.randn(batchsize, channels, 16, device=DEVICE, dtype=DTYPE)
+    coeffs = torch.randn(
+        channels, channels, NUM_PIN_LINEAR_BASIS_ELEMENTS, device=DEVICE, dtype=DTYPE
+    )
+
+    if DEVICE == torch.device("cuda"):
+        torch.cuda.synchronize()
+    t0 = time.time()
+    out_v1 = equi_linear(x, coeffs, use_v2=False)
+    dt1 = time.time() - t0
+
+    if DEVICE == torch.device("cuda"):
+        torch.cuda.synchronize()
+    t0 = time.time()
+    out_v2 = linear_v2(x, coeffs)
+    dt2 = time.time() - t0
+
+    if DEVICE == torch.device("cuda"):
+        torch.cuda.synchronize()
+    t0 = time.time()
+    out_v2 = linear_v2_compiled(x, coeffs)
+    dt3 = time.time() - t0
+
+    # torch.testing.assert_close(out_v1, out_v2)
+    return dt1, dt2, dt3
+
+
+if __name__ == "__main__":
+    benchmark(10000)
+
+    results = {}
+    n_particles = 2 ** np.arange(15)
+    for n in list(n_particles):
+        dt1, dt2, dt3 = [], [], []
+        for _ in range(50):
+            t1, t2, t3 = benchmark(n)
+            dt1.append(t1)
+            dt2.append(t2)
+            dt3.append(t3)
+
+        results[n] = {"v1": dt1, "v2": dt2, "v3": dt3}
+        # info = lambda x: f"{np.mean(x):.2e}+/-{np.std(x):.2e}"
+        info = lambda x: f"{np.mean(x):.2e}"
+        print(
+            f"n_particles = {n:>10}:   dt_v1 = {info(dt1)}s, dt_v2 = {info(dt2)}s, dt_v3 = {info(dt3)}s"
+        )
+
+    v1_mean = np.array([np.mean(v["v1"]) for v in results.values()])
+    v1_std = np.array([np.std(v["v1"]) for v in results.values()])
+    v2_mean = np.array([np.mean(v["v2"]) for v in results.values()])
+    v2_std = np.array([np.std(v["v2"]) for v in results.values()])
+    v3_mean = np.array([np.mean(v["v3"]) for v in results.values()])
+    v3_std = np.array([np.std(v["v3"]) for v in results.values()])
+
+    fig, axs = plt.subplots(
+        2,
+        1,
+        figsize=(5, 3),
+        sharex=True,
+        gridspec_kw={"height_ratios": [3, 1], "hspace": 0},
+    )
+    axs[0].set_xscale("log")
+    axs[0].set_yscale("log")
+    axs[0].plot(n_particles, v1_mean, label="v1 (default)", color="r")
+    axs[0].plot(n_particles, v2_mean, label="v2 (masking)", color="g")
+    axs[0].plot(n_particles, v3_mean, label="v2 compiled (masking)", color="b")
+    axs[0].fill_between(
+        n_particles, v1_mean + v1_std, v1_mean - v1_std, color="r", alpha=0.3
+    )
+    axs[0].fill_between(
+        n_particles, v2_mean + v2_std, v2_mean - v2_std, color="g", alpha=0.3
+    )
+    axs[0].fill_between(
+        n_particles, v3_mean + v3_std, v3_mean - v3_std, color="b", alpha=0.3
+    )
+    axs[0].legend()
+    axs[0].set_ylabel(r"Time $t$ [s]")
+    axs[0].set_xlabel("Number of particles")
+
+    axs[1].set_yscale("log")
+    axs[1].plot(n_particles, 1 + 0 * n_particles, "r--")
+    axs[1].plot(n_particles, v2_mean / v1_mean, color="g")
+    axs[1].plot(n_particles, v3_mean / v1_mean, color="b")
+    axs[1].set_ylabel(r"$t_{v2}/t_{v1}$")
+
+    fig.suptitle(f"Time benchmarking for linear layer on {DEVICE}")
+    full_str = "SO+13" if USE_FULLY_CONNECTED_SUBGROUP else "O13"
+    fig.savefig(f"benchmark_{DEVICE}_{full_str}.pdf", bbox_inches="tight")
+    plt.close()


### PR DESCRIPTION
Changes
- Add function `linear_v2_compiled` (uses masking + `torch.compile`) as alternative to the sparse matrix multiplication default

TODO
- Check for further optimizations
- Check how much this speeds up the full GATr code

Benchmarks:

| ![benchmark_cpu_O13](https://github.com/user-attachments/assets/b3266e14-c2ee-4b1f-9f41-affe846a4466) | ![benchmark_cpu_SO+13](https://github.com/user-attachments/assets/5fa9b7dc-0f38-4e9d-99ee-8387909a2c45) |
|------|--------|
| ![benchmark_cuda_O13](https://github.com/user-attachments/assets/4a6876b9-1fe5-478c-ba1d-c54114e65a3a) | ![benchmark_cuda_SO+13](https://github.com/user-attachments/assets/22982771-d9f4-41c7-8ffa-30cc486bd3a2) |