### PR TITLE
Modify experiment code for multi-GPU training

### DIFF
--- a/experiments/amplitudes/experiment.py
+++ b/experiments/amplitudes/experiment.py
@@ -366,7 +366,7 @@ class AmplitudeExperiment(BaseExperiment):
         dataset_titles = [
             DATASET_TITLE_DICT[dataset] for dataset in self.cfg.data.dataset
         ]
-        model_title = MODEL_TITLE_DICT[type(self.model.net).__name__]
+        model_title = MODEL_TITLE_DICT[self.cfg.model.net._target_.rsplit(".", 1)[-1]]
         title = [f"{model_title}: {dataset_title}" for dataset_title in dataset_titles]
         LOGGER.info(f"Creating plots in {plot_path}")
 

--- a/experiments/amplitudes/experiment.py
+++ b/experiments/amplitudes/experiment.py
@@ -133,7 +133,7 @@ class AmplitudeExperiment(BaseExperiment):
 
             # preprocess data
             amplitudes_prepd, prepd_mean, prepd_std = preprocess_amplitude(amplitudes)
-            if type(self.model.net).__name__ in BASELINE_MODELS:
+            if self.cfg.model.net._target_.rsplit(".", 1)[-1] in BASELINE_MODELS:
                 particles_prepd, _, _ = preprocess_particles(particles)
             else:
                 particles_prepd = particles / particles.std()

--- a/experiments/base_experiment.py
+++ b/experiments/base_experiment.py
@@ -137,8 +137,9 @@ class BaseExperiment:
         )
         if self.cfg.use_mlflow:
             log_mlflow("num_parameters", float(num_parameters), step=0)
+        modelname = self.cfg.model.net._target_.rsplit(".", 1)[-1]
         LOGGER.info(
-            f"Instantiated model {type(self.model.net).__name__} with {num_parameters} learnable parameters"
+            f"Instantiated model {modelname} with {num_parameters} learnable parameters"
         )
 
         if self.cfg.ema:

--- a/experiments/base_experiment.py
+++ b/experiments/base_experiment.py
@@ -1,5 +1,6 @@
 import numpy as np
 import torch
+import torch.distributed as dist
 
 import os, time
 import zipfile
@@ -19,7 +20,7 @@ import gatr.layers.mlp.mlp
 import gatr.primitives.linear
 from experiments.misc import get_device, flatten_dict
 import experiments.logger
-from experiments.logger import LOGGER, MEMORY_HANDLER, FORMATTER
+from experiments.logger import LOGGER, MEMORY_HANDLER, FORMATTER, RankFilter
 from experiments.mlflow import log_mlflow
 
 from gatr.layers import MLPConfig, SelfAttentionConfig
@@ -34,8 +35,11 @@ MIN_STEP_SKIP = 1000
 
 
 class BaseExperiment:
-    def __init__(self, cfg):
+    def __init__(self, cfg, rank, world_size):
         self.cfg = cfg
+        self.rank = rank
+        self.world_size = world_size
+        self.is_master = rank == 0
 
     def __call__(self):
         # pass all exceptions to the logger
@@ -73,9 +77,10 @@ class BaseExperiment:
         t0 = time.time()
 
         # save config
-        LOGGER.debug(OmegaConf.to_yaml(self.cfg))
-        self._save_config("config.yaml", to_mlflow=True)
-        self._save_config(f"config_{self.cfg.run_idx}.yaml")
+        if self.is_master:
+            LOGGER.debug(OmegaConf.to_yaml(self.cfg))
+            self._save_config("config.yaml", to_mlflow=True)
+            self._save_config(f"config_{self.cfg.run_idx}.yaml")
 
         self.init_physics()
         self.init_geometric_algebra()
@@ -93,7 +98,7 @@ class BaseExperiment:
         if self.cfg.evaluate:
             self.evaluate()
 
-        if self.cfg.plot and self.cfg.save:
+        if self.cfg.plot and self.cfg.save and self.is_master:
             self.plot()
 
         if self.device == torch.device("cuda"):
@@ -172,6 +177,13 @@ class BaseExperiment:
         self.model.to(self.device, dtype=self.dtype)
         if self.ema is not None:
             self.ema.to(self.device)
+
+        if self.world_size > 1:
+            self.model.net = torch.nn.parallel.DistributedDataParallel(
+                self.model.net,
+                device_ids=[self.rank],
+                find_unused_parameters=True,  # avoid warnings for GATr models that have unused weights in linear_out
+            )
 
     def _init(self):
         run_name = self._init_experiment()
@@ -327,12 +339,16 @@ class BaseExperiment:
         # add new handlers to logger
         LOGGER.propagate = False  # avoid duplicate log outputs
 
+        # only log the rank==0 process
+        rank_filter = RankFilter(rank=self.rank)
+        LOGGER.addFilter(rank_filter)
+
         experiments.logger.LOGGING_INITIALIZED = True
         LOGGER.debug("Logger initialized")
 
     def _init_backend(self):
         self.device = get_device()
-        LOGGER.info(f"Using device {self.device}")
+        LOGGER.info(f"Using device {self.device}; see {self.world_size} GPUs")
 
         if self.cfg.training.dtype == "float32":
             self.dtype = torch.float32
@@ -495,9 +511,12 @@ class BaseExperiment:
 
         # recycle trainloader
         def cycle(iterable):
+            epoch = 0
             while True:
+                self.train_loader.sampler.set_epoch(epoch)
                 for x in iterable:
                     yield x
+                epoch += 1
 
         iterator = iter(cycle(self.train_loader))
         for step in range(self.cfg.training.iterations):
@@ -604,6 +623,9 @@ class BaseExperiment:
             self.scheduler.step()
 
         # collect metrics
+        if self.world_size > 1:
+            dist.all_reduce(loss, op=dist.ReduceOp.SUM)
+            loss /= self.world_size
         self.train_loss.append(loss.item())
         self.train_lr.append(self.optimizer.param_groups[0]["lr"])
         self.train_grad_norm.append(grad_norm)
@@ -642,6 +664,9 @@ class BaseExperiment:
                 else:
                     loss, metric = self._batch_loss(data)
 
+                if self.world_size > 1:
+                    dist.all_reduce(loss, op=dist.ReduceOp.SUM)
+                    loss /= self.world_size
                 losses.append(loss.cpu().item())
                 for key, value in metric.items():
                     metrics[key].append(value)

--- a/experiments/base_experiment.py
+++ b/experiments/base_experiment.py
@@ -98,7 +98,7 @@ class BaseExperiment:
         if self.cfg.evaluate:
             self.evaluate()
 
-        if self.cfg.plot and self.cfg.save and self.is_master:
+        if self.cfg.plot and self.cfg.save:
             self.plot()
 
         if self.device == torch.device("cuda"):
@@ -230,6 +230,9 @@ class BaseExperiment:
                 self.cfg.warm_start_idx = 0
                 self.cfg.run_name = run_name
                 self.cfg.run_dir = run_dir
+
+            # only save main process
+            self.cfg.save = self.cfg.save and self.is_master
 
             # only use mlflow if save=True
             self.cfg.use_mlflow = (

--- a/experiments/eventgen/dataset.py
+++ b/experiments/eventgen/dataset.py
@@ -4,7 +4,7 @@ import torch
 class EventDataset(torch.utils.data.Dataset):
     def __init__(self, events, dtype):
         self.events = [
-            torch.tensor(events_onedataset, dtype=dtype) for events_onedataset in events
+            events_onedataset.to(dtype=dtype) for events_onedataset in events
         ]
         self.events_eff = [e.clone() for e in self.events]
         self.lens = [len(events_onedataset) for events_onedataset in self.events]
@@ -20,9 +20,11 @@ class EventDataset(torch.utils.data.Dataset):
 
 
 class EventDataLoader(torch.utils.data.DataLoader):
-    def __init__(self, dataset, batch_size, shuffle=True, drop_last=False):
+    def __init__(self, *args, shuffle=None, **kwargs):
         super().__init__(
-            dataset, batch_size=batch_size, shuffle=shuffle, drop_last=drop_last
+            *args,
+            shuffle=shuffle,
+            **kwargs,
         )
         self.shuffle = shuffle
 

--- a/experiments/eventgen/experiment.py
+++ b/experiments/eventgen/experiment.py
@@ -178,7 +178,7 @@ class EventGenerationExperiment(BaseExperiment):
         )
         self.train_loader = EventDataLoader(
             dataset=train_dataset,
-            batch_size=self.cfg.training.batchsize,
+            batch_size=self.cfg.training.batchsize // self.world_size,
             sampler=train_sampler,
         )
 
@@ -193,7 +193,7 @@ class EventGenerationExperiment(BaseExperiment):
         )
         self.test_loader = EventDataLoader(
             dataset=test_dataset,
-            batch_size=self.cfg.evaluation.batchsize,
+            batch_size=self.cfg.evaluation.batchsize // self.world_size,
             sampler=test_sampler,
         )
 
@@ -208,7 +208,7 @@ class EventGenerationExperiment(BaseExperiment):
         )
         self.val_loader = EventDataLoader(
             dataset=val_dataset,
-            batch_size=self.cfg.evaluation.batchsize,
+            batch_size=self.cfg.evaluation.batchsize // self.world_size,
             sampler=val_sampler,
         )
 

--- a/experiments/logger.py
+++ b/experiments/logger.py
@@ -11,3 +11,12 @@ LOGGER = logging.getLogger("lorentz-gatr")
 LOGGER.setLevel(logging.DEBUG)
 LOGGER.addHandler(MEMORY_HANDLER)
 LOGGING_INITIALIZED = False
+
+
+class RankFilter(logging.Filter):
+    def __init__(self, rank=0):
+        super().__init__()
+        self.rank = rank
+
+    def filter(self, record):
+        return self.rank == 0

--- a/experiments/tagging/experiment.py
+++ b/experiments/tagging/experiment.py
@@ -16,8 +16,6 @@ from experiments.tagging.embedding import embed_tagging_data_into_ga
 from experiments.logger import LOGGER
 from experiments.mlflow import log_mlflow
 
-MODEL_TITLE_DICT = {"GATr": "GATr"}
-
 
 class TaggingExperiment(BaseExperiment):
     """
@@ -223,7 +221,7 @@ class TaggingExperiment(BaseExperiment):
     def plot(self):
         plot_path = os.path.join(self.cfg.run_dir, f"plots_{self.cfg.run_idx}")
         os.makedirs(plot_path, exist_ok=True)
-        model_title = MODEL_TITLE_DICT[type(self.model.net).__name__]
+        model_title = self.cfg.model.net._target_.rsplit(".", 1)[-1]
         title = model_title
         LOGGER.info(f"Creating plots in {plot_path}")
 

--- a/experiments/tagging/experiment.py
+++ b/experiments/tagging/experiment.py
@@ -81,20 +81,38 @@ class TaggingExperiment(BaseExperiment):
         LOGGER.info(f"Finished creating datasets after {dt:.2f} s = {dt/60:.2f} min")
 
     def _init_dataloader(self):
+        train_sampler = torch.utils.data.DistributedSampler(
+            self.data_train,
+            num_replicas=self.world_size,
+            rank=self.rank,
+            shuffle=True,
+        )
         self.train_loader = DataLoader(
             dataset=self.data_train,
             batch_size=self.cfg.training.batchsize,
-            shuffle=True,
+            sampler=train_sampler,
+        )
+        test_sampler = torch.utils.data.DistributedSampler(
+            self.data_test,
+            num_replicas=self.world_size,
+            rank=self.rank,
+            shuffle=False,
         )
         self.test_loader = DataLoader(
             dataset=self.data_test,
             batch_size=self.cfg.evaluation.batchsize,
+            sampler=test_sampler,
+        )
+        val_sampler = torch.utils.data.DistributedSampler(
+            self.data_val,
+            num_replicas=self.world_size,
+            rank=self.rank,
             shuffle=False,
         )
         self.val_loader = DataLoader(
             dataset=self.data_val,
             batch_size=self.cfg.evaluation.batchsize,
-            shuffle=False,
+            sampler=val_sampler,
         )
 
         LOGGER.info(

--- a/experiments/tagging/experiment.py
+++ b/experiments/tagging/experiment.py
@@ -87,7 +87,7 @@ class TaggingExperiment(BaseExperiment):
         )
         self.train_loader = DataLoader(
             dataset=self.data_train,
-            batch_size=self.cfg.training.batchsize,
+            batch_size=self.cfg.training.batchsize // self.world_size,
             sampler=train_sampler,
         )
         test_sampler = torch.utils.data.DistributedSampler(
@@ -98,7 +98,7 @@ class TaggingExperiment(BaseExperiment):
         )
         self.test_loader = DataLoader(
             dataset=self.data_test,
-            batch_size=self.cfg.evaluation.batchsize,
+            batch_size=self.cfg.evaluation.batchsize // self.world_size,
             sampler=test_sampler,
         )
         val_sampler = torch.utils.data.DistributedSampler(
@@ -109,7 +109,7 @@ class TaggingExperiment(BaseExperiment):
         )
         self.val_loader = DataLoader(
             dataset=self.data_val,
-            batch_size=self.cfg.evaluation.batchsize,
+            batch_size=self.cfg.evaluation.batchsize // self.world_size,
             sampler=val_sampler,
         )
 

--- a/experiments/tagging/jetclassexperiment.py
+++ b/experiments/tagging/jetclassexperiment.py
@@ -130,7 +130,7 @@ class JetClassTaggingExperiment(TaggingExperiment):
         )
         self.train_loader = DataLoader(
             dataset=self.data_train,
-            batch_size=self.cfg.training.batchsize,
+            batch_size=self.cfg.training.batchsize // self.world_size,
             drop_last=True,
             num_workers=num_workers["train"],
             sampler=train_sampler,
@@ -143,7 +143,7 @@ class JetClassTaggingExperiment(TaggingExperiment):
         )
         self.val_loader = DataLoader(
             dataset=self.data_val,
-            batch_size=self.cfg.evaluation.batchsize,
+            batch_size=self.cfg.evaluation.batchsize // self.world_size,
             drop_last=True,
             num_workers=num_workers["val"],
             sampler=val_sampler,
@@ -156,7 +156,7 @@ class JetClassTaggingExperiment(TaggingExperiment):
         )
         self.test_loader = DataLoader(
             dataset=self.data_test,
-            batch_size=self.cfg.evaluation.batchsize,
+            batch_size=self.cfg.evaluation.batchsize // self.world_size,
             drop_last=False,
             num_workers=num_workers["test"],
             sampler=test_sampler,

--- a/experiments/tagging/jetclassexperiment.py
+++ b/experiments/tagging/jetclassexperiment.py
@@ -123,25 +123,43 @@ class JetClassTaggingExperiment(TaggingExperiment):
             label: min(self.cfg.jc_params.num_workers, self.num_files[label])
             for label in ["train", "test", "val"]
         }
+        train_sampler = torch.utils.data.DistributedSampler(
+            self.data_train,
+            num_replicas=self.world_size,
+            rank=self.rank,
+        )
         self.train_loader = DataLoader(
             dataset=self.data_train,
             batch_size=self.cfg.training.batchsize,
             drop_last=True,
             num_workers=num_workers["train"],
+            sampler=train_sampler,
             **self.loader_kwargs,
+        )
+        val_sampler = torch.utils.data.DistributedSampler(
+            self.data_val,
+            num_replicas=self.world_size,
+            rank=self.rank,
         )
         self.val_loader = DataLoader(
             dataset=self.data_val,
             batch_size=self.cfg.evaluation.batchsize,
             drop_last=True,
             num_workers=num_workers["val"],
+            sampler=val_sampler,
             **self.loader_kwargs,
+        )
+        test_sampler = torch.utils.data.DistributedSampler(
+            self.data_test,
+            num_replicas=self.world_size,
+            rank=self.rank,
         )
         self.test_loader = DataLoader(
             dataset=self.data_test,
             batch_size=self.cfg.evaluation.batchsize,
             drop_last=False,
             num_workers=num_workers["test"],
+            sampler=test_sampler,
             **self.loader_kwargs,
         )
 

--- a/run.py
+++ b/run.py
@@ -1,4 +1,7 @@
 import hydra
+import torch
+import torch.multiprocessing as mp
+import torch.distributed as dist
 from experiments.amplitudes.experiment import AmplitudeExperiment
 from experiments.tagging.experiment import TopTaggingExperiment, QGTaggingExperiment
 from experiments.eventgen.processes import (
@@ -12,26 +15,52 @@ from experiments.tagging.finetuneexperiment import TopTaggingFineTuneExperiment
 
 @hydra.main(config_path="config", config_name="amplitudes", version_base=None)
 def main(cfg):
+    world_size = torch.cuda.device_count() if torch.cuda.is_available() else 1
+
+    if world_size > 1:
+        assert torch.cuda.is_available(), "Distributed training only supported on GPU"
+        # multiple GPUs -> spawn processes
+        mp.spawn(ddp_worker, nprocs=world_size, args=(cfg, world_size))
+    else:
+        # no CPU or only one GPU -> run on main process
+        ddp_worker(rank=0, cfg=cfg, world_size=world_size)
+
+
+def ddp_worker(rank, cfg, world_size):
+    if world_size > 1:
+        # set up communication between processes
+        dist.init_process_group(
+            backend="nccl",
+            init_method="tcp://127.0.0.1:4242",
+            world_size=world_size,
+            rank=rank,
+        )
+        torch.cuda.set_device(rank)
+
     if cfg.exp_type == "amplitudes":
-        exp = AmplitudeExperiment(cfg)
+        constructor = AmplitudeExperiment
     elif cfg.exp_type == "toptagging":
-        exp = TopTaggingExperiment(cfg)
+        constructor = TopTaggingExperiment
     elif cfg.exp_type == "qgtagging":
-        exp = QGTaggingExperiment(cfg)
+        constructor = QGTaggingExperiment
     elif cfg.exp_type == "jctagging":
-        exp = JetClassTaggingExperiment(cfg)
+        constructor = JetClassTaggingExperiment
     elif cfg.exp_type == "toptaggingft":
-        exp = TopTaggingFineTuneExperiment(cfg)
+        constructor = TopTaggingFineTuneExperiment
     elif cfg.exp_type == "ttbar":
-        exp = ttbarExperiment(cfg)
+        constructor = ttbarExperiment
     elif cfg.exp_type == "ttbar-onshell":
-        exp = ttbarOnshellExperiment(cfg)
+        constructor = ttbarOnshellExperiment
     elif cfg.exp_type == "zmumu":
-        exp = zmumuExperiment(cfg)
+        constructor = zmumuExperiment
     else:
         raise ValueError(f"exp_type {cfg.exp_type} not implemented")
 
+    exp = constructor(cfg, rank, world_size)
     exp()
+
+    if world_size > 1:
+        dist.destroy_process_group()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
In the end this didn't require too many changes, so I would suggest merging this into main. @vbpla what do you think?

### Changes
- If multiple GPUs are specified, we launch several processes in `run.py` with one experiment class each and communication through the `nccl` protocol
- `base_experiment.py` has access to `world_size` and `rank` -> Log and plot only on `rank==0`
- Use `DistributedSampler` in the `DataLoader` of each experiment (required some extra care for the custom `DataLoader` of the `eventgen` experiment)

### Comments
- Key concepts in `DDP`: `world_size` = #GPUs, `rank` = index of current GPU
- Almost all multi-gpu stuff is handled in `run.py` and `base_experiment.py`; the only thing one has to be careful with when adding a new experiment is to use `torch.utils.data.DistributedSampler` as an input to the `DataLoader`
- Metrics can be synchronized across GPUs with e.g. `dist.all_reduce`; currently this is only done for the `loss`; we could also do that for other metrics, but that gets ugly
- DDP complains if some parameters of the model are not used in the loss, but for GATr this is common because usually only either the scalar of the multivector outputs are used; we could remove the unused outputs in the code, but that would be super ugly; so we use `find_unused_parameters=True` when calling `torch.nn.parallel.DistributedDataParallel`, this adds some extra overhead but then we don't get errors